### PR TITLE
remove superfluous parameter "self.install_id"

### DIFF
--- a/custom_components/studer_xcom/entity_base.py
+++ b/custom_components/studer_xcom/entity_base.py
@@ -116,7 +116,7 @@ class StuderEntityHelper:
             # Create a Sensor, Binary_Sensor, Number, Select, Switch or other entity for this status
             ha_entity = None                
             try:
-                ha_entity = target_class(self.coordinator, self.install_id, entity)
+                ha_entity = target_class(self.coordinator, entity)
                 ha_entities.append(ha_entity)
             except Exception as  ex:
                 _LOGGER.warning(f"Could not instantiate {platform} entity class for {entity.object_id}. Details: {ex}")


### PR DESCRIPTION
After code cleanup this parameter needed to be removed  to be able to instantiate the entity classes again, otherwise we get this error:

`WARNING (MainThread) [custom_components.studer_xcom.entity_base] Could not instantiate switch entity class for studer_4001_vt1_10008. Details: StuderSwitch.__init__() takes 3 positional arguments but 4 were given`